### PR TITLE
fix logger message type

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -19,15 +19,15 @@ class Logger {
         return `[${timestamp}] [${type}] ${message}`;
     }
 
-    writeToFile(message) {
-        const formattedMessage = this.formatMessage(message);
+    writeToFile(message, type = 'INFO') {
+        const formattedMessage = this.formatMessage(message, type);
         fs.appendFileSync(this.logFile, formattedMessage + '\n');
     }
 
     log(message, type = 'INFO') {
         const formattedMessage = this.formatMessage(message, type);
         console.log(formattedMessage);
-        this.writeToFile(message);
+        this.writeToFile(message, type);
     }
 
     error(message) {


### PR DESCRIPTION
## Summary
- ensure logger writes messages with correct level to log file

## Testing
- `npm run test-setup` *(fails: Cannot find module 'test-setup.js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689713ee72348320a1069383b2634c22