### PR TITLE
Fix Python crawler execution path for AWS

### DIFF
--- a/src/services/CrawlerService.js
+++ b/src/services/CrawlerService.js
@@ -1,4 +1,5 @@
 const { spawn, execSync } = require('child_process');
+const path = require('path');
 const logger = require('../utils/logger');
 
 class CrawlerService {
@@ -50,10 +51,15 @@ class CrawlerService {
                 return;
             }
             
+            // Resolve script path so it works regardless of working directory
+            const scriptPath = path.join(__dirname, '..', '..', 'python', 'crawl_and_update_fixed.py');
+            const repoRoot = path.join(__dirname, '..', '..');
+
             // Now spawn the process with the found command
             try {
-                pythonProcess = spawn(commandUsed, ['python/crawl_and_update_fixed.py'], {
-                    stdio: ['pipe', 'pipe', 'pipe']
+                pythonProcess = spawn(commandUsed, [scriptPath], {
+                    stdio: ['pipe', 'pipe', 'pipe'],
+                    cwd: repoRoot
                 });
                 logger.info(`Using Python command: ${commandUsed}`);
             } catch (error) {


### PR DESCRIPTION
## Summary
- resolve crawler script path with `path.join` and set `cwd` so the Python crawler runs reliably on AWS

## Testing
- `npm run test-setup` *(fails: Cannot find module '/workspace/Web_tracking_ASIN_Amazon/test-setup.js')*


------
https://chatgpt.com/codex/tasks/task_e_689714ae56d883208d496c53b6fd7c5c